### PR TITLE
Disable tslint rules in wallabyTest.ts

### DIFF
--- a/src/wallabyTest.ts
+++ b/src/wallabyTest.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:ordered-imports file-name-casing */
 import './polyfills';
 import 'core-js/es7/reflect';
 import 'zone.js/dist/zone-testing';


### PR DESCRIPTION
I found myself to follow tslint rules and fix linting errors by one click IDE suggestions.
the problem with that is it will reorder imports, which then causes the erros like:
```TypeError: Cannot read property 'getComponentFromError' of null```
and 
```Uncaught ReferenceError: Zone is not defined```

Added the line which will disable those annoying in this file rules